### PR TITLE
V2.1.0: Adds functionality to remove orphaned translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ export const config = {
 };
 ```
 
+> Note: if you want to set a different `sourceLanguage` for one of your languages than the default, make sure this language is listed AFTER its source language. For example, German's source language (listed second) is Dutch (listed first)
+
 Modify the configuration according to your project's needs.
 
 ## Translations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translategpt",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A tool to generate language translations using AI.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
In V2.0 and below, if you removed a translation from the source, it did not get removed from from the translated files too. We are calling these orphaned translations. Running from V2.1 and above will remove these orphans, and prevent new ones from being created